### PR TITLE
docs: Update Expo installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install @colorfy-software/zfy
 
 {% tab title="Expo" %}
 ```
-expo install @colorfy-software/zfy
+npx expo install @colorfy-software/zfy
 ```
 {% endtab %}
 {% endtabs %}
@@ -28,7 +28,7 @@ expo install @colorfy-software/zfy
 
 * Fully typed with TypeScript
 * Standardized access/update API backed by Immer
-* Ability to manage & consume multiples stores at once
+* Ability to manage & consume multiple stores at once
 * Simple API for store creation with custom middlewares
 * Out-of-the-box persist gate component & rehydration hook
 * Logger, persist & subscribe middlewares available via a simple flag


### PR DESCRIPTION
Hi,
The expo install command referenced in the README is outdated because Expo SDK package (`expo`) now contains a locally installed version of Expo CLI which requires using `npx expo install` to install a package in any Expo project. The command currently referenced was true when `expo-cli` (the global CLI) used to exist but it has been deprecated.

Also, found a typo to fix under "features" listed.